### PR TITLE
Fixes incorrect link pointing to personal repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ when building digital services.
 
 ## Adding new guidance
 
-Create a new Markdown (.md) file in the [DfE Architecture repo](https://github.com/luke-slowen/architecture) that follows this pattern, add a link to it
+Create a new Markdown (.md) file in the [DfE Architecture repo](https://github.com/DFE-Digital/enterprise-architecture) that follows this pattern, add a link to it
 from this page, and make a pull request:
 
 ```markdown


### PR DESCRIPTION
There was a link in the README that pointed to a personal repository. This PR fixes that link.