### PR TITLE
Updates links to DfE Technical Guidance

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ It complements the [GDS Service Manual](https://www.gov.uk/service-manual) and i
 which covers service design more broadly.
 
 It should be used in conjunction with the
-[DfE Digital Technical Guidance](https://dfe-digital.github.io/technology-guidance),
+[DfE Digital Technical Guidance](https://dfe-digital.github.io/technical-guidance),
 when building digital services.
 
 ## Service offer

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ It complements the [GDS Service Manual](https://www.gov.uk/service-manual) and i
 which covers service design more broadly.
 
 It should be used in conjunction with the
-[DfE Digital Technical Guidance](https://dfe-digital.github.io/technology-guidance),
+[DfE Digital Technical Guidance](https://dfe-digital.github.io/technical-guidance),
 when building digital services.
 
 ## Adding new guidance


### PR DESCRIPTION
DfE Digital Technical Guidance has moved from:

`https://dfe-digital.github.io/technology-guidance`

To:

`https://dfe-digital.github.io/technical-guidance`

This is due to a repository rename. This pull requests updates the links to this guidance.